### PR TITLE
Add the podspec and fix readme for React Native 0.60.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,6 @@ Update the AppDelegate.m file to include the following:
 
 # iOS
 ```objectivec
-/* RN >= 0.60.0 linked automatically */
-#import <RNScreenshotDetector.h>
-/* RN < 0.60.0 linked manually */
 #import <RNScreenshotDetector/RNScreenshotDetector.h>
 
 .........

--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 
 # react-native-screenshot-detector
 
-Note: this project is designed to work with the newer version of React Native library imports, i.e. React Native >= 0.40.0
+Note: this project is designed to work with the newer version of React Native library imports, i.e. React Native >= 0.40.0, and will only work on iOS as Android does not provide the underlying functionality needed to track screenshots.
 
 ## Getting started
 
-`$ npm install react-native-screenshot-detector --save`
+PRE React Native 0.60.0
+
+`$ npm install react-native-screenshot-detector`
 
 `$ react-native link react-native-screenshot-detector`
 
+POST React Native 0.60.0
+
+`$ npm install react-native-screenshot-detector`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -5,21 +5,28 @@ Note: this project is designed to work with the newer version of React Native li
 
 ## Getting started
 
-PRE React Native 0.60.0
+React Native < 0.60.0
 
 `$ npm install react-native-screenshot-detector`
 
 `$ react-native link react-native-screenshot-detector`
 
-POST React Native 0.60.0
+React Native >= 0.60.0
 
 `$ npm install react-native-screenshot-detector`
 
 ## Usage
 
+Update the AppDelegate.m file to include the following:
+
 # iOS
 ```objectivec
+/* RN >= 0.60.0 linked automatically */
+#import <RNScreenshotDetector.h>
+/* RN < 0.60.0 linked manually */
 #import <RNScreenshotDetector/RNScreenshotDetector.h>
+
+.........
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {

--- a/RNScreenshotDetector.podspec
+++ b/RNScreenshotDetector.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name         = package['name']
+  s.name         = 'RNScreenshotDetector'
   s.version      = package['version']
   s.summary      = package['description']
   s.license      = package['license']
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.homepage     = package['homepage']
   s.platform     = :ios, "9.0"
 
-  s.source       = { :git => "https://github.com/blend/react-native-screenshot-detector.git", :tag => "v#{s.version}" }
+  s.source       = { :git => "https://github.com/iamacup/react-native-screenshot-detector.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React'

--- a/RNScreenshotDetector.podspec
+++ b/RNScreenshotDetector.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.homepage     = package['homepage']
   s.platform     = :ios, "9.0"
 
-  s.source       = { :git => "https://github.com/iamacup/react-native-screenshot-detector.git", :tag => "v#{s.version}" }
+  s.source       = { :git => "https://github.com/blend/react-native-screenshot-detector.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React'

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
 {
   "name": "react-native-screenshot-detector",
   "version": "1.0.0",
-  "description": "",
+  "homepage": "https://github.com/iamacup/react-native-screenshot-detector",
+  "description": "A tool for detecting ios screenshots on iOS",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -13,7 +14,7 @@
   "author": "gcarling",
   "repository": {
     "type": "git",
-    "url": "https://github.com/blendlabs/react-native-screenshot-detector"
+    "url": "https://github.com/iamacup/react-native-screenshot-detector"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 
 {
   "name": "react-native-screenshot-detector",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "homepage": "https://github.com/iamacup/react-native-screenshot-detector",
   "description": "A tool for detecting ios screenshots on iOS",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 {
   "name": "react-native-screenshot-detector",
   "version": "1.0.1",
-  "homepage": "https://github.com/iamacup/react-native-screenshot-detector",
+  "homepage": "https://github.com/blend/react-native-screenshot-detector",
   "description": "A tool for detecting ios screenshots on iOS",
   "main": "index.js",
   "scripts": {
@@ -14,7 +14,7 @@
   "author": "gcarling",
   "repository": {
     "type": "git",
-    "url": "https://github.com/iamacup/react-native-screenshot-detector"
+    "url": "https://github.com/blend/react-native-screenshot-detector"
   },
   "license": "MIT"
 }

--- a/react-native-screenshot-detector.podspec
+++ b/react-native-screenshot-detector.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.homepage     = package['homepage']
   s.platform     = :ios, "9.0"
 
-  s.source       = { :git => "https://github.com/iamacup/react-native-screenshot-detector.git", :tag => "v#{s.version}" }
+  s.source       = { :git => "https://github.com/blend/react-native-screenshot-detector.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React'

--- a/react-native-screenshot-detector.podspec
+++ b/react-native-screenshot-detector.podspec
@@ -1,0 +1,19 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = package['name']
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+
+  s.authors      = package['author']
+  s.homepage     = package['homepage']
+  s.platform     = :ios, "9.0"
+
+  s.source       = { :git => "https://github.com/iamacup/react-native-screenshot-detector.git", :tag => "v#{s.version}" }
+  s.source_files  = "ios/**/*.{h,m}"
+
+  s.dependency 'React'
+end


### PR DESCRIPTION
Hi

There are some updates needed to this repo to make it auto link with the new React Native 0.60.x

This pull will fix auto linking and make this error stop appearing:

```[!] use_native_modules! skipped the react-native dependency 'react-native-screenshot-detector
'. No podspec file was found.

    - Check to see if there is an updated version that contains the necessary podspec file
    - Contact the library maintainers or send them a PR to add a podspec. The react-native-webview podspec
    is a good example of a package.json driven podspec. See
    https://github.com/react-native-community/react-native-webview/blob/master/react-native-webview.podspec
    - If necessary, you can disable autolinking for the dependency and link it manually. See
    https://github.com/react-native-community/cli/blob/master/docs/autolinking.md#how-can-i-disable-autolinking-for-unsupported-library

```

# EDIT:

# I have published my pull request on npm as `react-native-screenshot-detect` for easy access to this because its been annoying me for awhile now... :)