### PR TITLE
fix(android): fail-closed when native module is missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+xcuserdata

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 xcuserdata
+android/build/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+xcuserdata
+android/build/
+Example/

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Accordingly, this library exports different APIs for Android and iOS. See [Usage
 import ScreenshotDetector from '@exodus/react-native-screenshot-detector';
 
 // iOS
-ScreenshotDetector.onScreenshot(() => {
+ScreenshotDetector.subscribe(() => {
   // yell at the user. We'll leave the choice of obscenities to you
 })
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,30 @@
 
-# react-native-screenshot-detector
+# @exodus/react-native-screenshot-detector
+
+*NOTE: forked and adapted from https://github.com/blend/react-native-screenshot-detector*
 
 The goal is to prevent the user from taking screenshots in your app.
 
-- Android: possible, via the [FLAG_SECURE flag](https://developer.android.com/reference/android/view/WindowManager.LayoutParams.html#FLAG_SECURE)
+- Android: possible via the [FLAG_SECURE flag](https://developer.android.com/reference/android/view/WindowManager.LayoutParams.html#FLAG_SECURE)
 - iOS: impossible, but you *can* detect them
 
 Accordingly, this library exports different APIs for Android and iOS. See [Usage](#usage) below.
 
 ## Getting started
 
-`$ npm install react-native-screenshot-detector --save`
+`$ npm install @exodus/react-native-screenshot-detector --save`
 
-`$ react-native link react-native-screenshot-detector`
+`$ react-native link @exodus/react-native-screenshot-detector`
 
 ## Usage
 
 ```javascript
-import ScreenshotDetector from 'react-native-screenshot-detector';
+import ScreenshotDetector from '@exodus/react-native-screenshot-detector';
 
 // iOS
-ScreenshotDetector.onScreenshot(yourHandler)
+ScreenshotDetector.onScreenshot(() => {
+  // yell at the user. We'll leave the choice of obscenities to you
+})
 
 // Android
 ScreenshotDetector.disableScreenshots()

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 
 # react-native-screenshot-detector
 
-Note: this project is designed to work with the newer version of React Native library imports, i.e. React Native >= 0.40.0
+The goal is to prevent the user from taking screenshots in your app.
+
+- Android: possible, via the [FLAG_SECURE flag](https://developer.android.com/reference/android/view/WindowManager.LayoutParams.html#FLAG_SECURE)
+- iOS: impossible, but you *can* detect them
+
+Accordingly, this library exports different APIs for Android and iOS. See [Usage](#usage) below.
 
 ## Getting started
 
@@ -9,34 +14,15 @@ Note: this project is designed to work with the newer version of React Native li
 
 `$ react-native link react-native-screenshot-detector`
 
-
 ## Usage
 
-# iOS
-```objectivec
-#import <RNScreenshotDetector/RNScreenshotDetector.h>
-
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
-{
-  // ... setup code
-
-  // Somewhere React Native will have placed something like
-  RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL...]
-
-  // Somewhere below this you can setup the screenshot detector to listen for events
-  RNScreenshotDetector* screenshotDetector = [[RNScreenshotDetector alloc] init];
-  [screenshotDetector setupAndListen:rootView.bridge];
-}
-```
-
-# In JS
 ```javascript
-import * as ScreenshotDetector from 'react-native-screenshot-detector';
+import ScreenshotDetector from 'react-native-screenshot-detector';
 
-// Subscribe callback to screenshots:
-this.eventEmitter = ScreenshotDetector.subscribe(function() { ... });
+// iOS
+ScreenshotDetector.onScreenshot(yourHandler)
 
-// Unsubscribe later (a good place would be componentWillUnmount)
-ScreenshotDetector.unsubscribe(this.eventEmitter);
+// Android
+ScreenshotDetector.disableScreenshots()
+ScreenshotDetector.enableScreenshots()
 ```
-  

--- a/RNScreenshotDetector.podspec
+++ b/RNScreenshotDetector.podspec
@@ -1,0 +1,23 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name                = "RNScreenshotDetector"
+  s.version             = package['version']
+  s.summary             = package['description']
+  s.homepage            = "https://github.com/ExodusMovement/react-native-screenshot-detector"
+  s.license             = package['license']
+  s.author              = package['author']
+  s.source              = { :git => 'https://github.com/ExodusMovement/react-native-screenshot-detector.git', :tag => "v#{s.version}" }
+  s.default_subspec     = 'Core'
+  s.requires_arc        = true
+  s.platform            = :ios, "7.0"
+
+  s.dependency 'React'
+
+  s.subspec 'Core' do |ss|
+    ss.source_files     = "RNScreenshotDetector/*.{h,m}"
+  end
+
+end

--- a/RNScreenshotDetector.podspec
+++ b/RNScreenshotDetector.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.dependency 'React'
 
   s.subspec 'Core' do |ss|
-    ss.source_files     = "RNScreenshotDetector/*.{h,m}"
+    ss.source_files     = "ios/RNScreenshotDetector/*.{h,m}"
   end
 
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,6 +31,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }
   

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,0 +1,36 @@
+
+buildscript {
+    repositories {
+        jcenter()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:1.3.1'
+    }
+}
+
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion 23
+    buildToolsVersion "23.0.1"
+
+    defaultConfig {
+        minSdkVersion 16
+        targetSdkVersion 22
+        versionCode 1
+        versionName "1.0"
+    }
+    lintOptions {
+        abortOnError false
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile 'com.facebook.react:react-native:+'
+}
+  

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,0 +1,6 @@
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.reactlibrary">
+
+</manifest>
+  

--- a/android/src/main/java/com/reactlibrary/RNScreenshotDetectorModule.java
+++ b/android/src/main/java/com/reactlibrary/RNScreenshotDetectorModule.java
@@ -1,6 +1,7 @@
 
 package com.reactlibrary;
 
+import android.app.Activity;
 import android.view.Window;
 import android.view.WindowManager;
 
@@ -25,25 +26,38 @@ public class RNScreenshotDetectorModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void disableScreenshots() {
-    getCurrentActivity().runOnUiThread(new Runnable() {
-      @Override
-      public void run() {
-        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
-      }
-    });
+    Activity currentActivity = getCurrentActivity();
+    if (currentActivity != null) {
+      currentActivity.runOnUiThread(new Runnable() {
+        @Override
+        public void run() {
+          Window window = getWindow();
+          if (window != null) {
+            window.setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
+          }
+        }
+      });
+    }
   }
 
   @ReactMethod
   public void enableScreenshots() {
-    getCurrentActivity().runOnUiThread(new Runnable() {
-      @Override
-      public void run() {
-        getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
-      }
-    });
+    Activity currentActivity = getCurrentActivity();
+    if (currentActivity != null) {
+      currentActivity.runOnUiThread(new Runnable() {
+        @Override
+        public void run() {
+          Window window = getWindow();
+          if (window != null) {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
+          }
+        }
+      });
+    }
   }
 
   private Window getWindow() {
-    return getCurrentActivity().getWindow();
+    Activity currentActivity = getCurrentActivity();
+    return currentActivity != null ? currentActivity.getWindow() : null;
   }
 }

--- a/android/src/main/java/com/reactlibrary/RNScreenshotDetectorModule.java
+++ b/android/src/main/java/com/reactlibrary/RNScreenshotDetectorModule.java
@@ -24,7 +24,7 @@ public class RNScreenshotDetectorModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void enableScreenshots() {
+  public void disableScreenshots() {
     getCurrentActivity().runOnUiThread(new Runnable() {
       @Override
       public void run() {
@@ -34,7 +34,7 @@ public class RNScreenshotDetectorModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void disableScreenshots() {
+  public void enableScreenshots() {
     getCurrentActivity().runOnUiThread(new Runnable() {
       @Override
       public void run() {

--- a/android/src/main/java/com/reactlibrary/RNScreenshotDetectorModule.java
+++ b/android/src/main/java/com/reactlibrary/RNScreenshotDetectorModule.java
@@ -1,0 +1,49 @@
+
+package com.reactlibrary;
+
+import android.view.Window;
+import android.view.WindowManager;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.Callback;
+
+public class RNScreenshotDetectorModule extends ReactContextBaseJavaModule {
+
+  private final ReactApplicationContext reactContext;
+
+  public RNScreenshotDetectorModule(ReactApplicationContext reactContext) {
+    super(reactContext);
+    this.reactContext = reactContext;
+  }
+
+  @Override
+  public String getName() {
+    return "RNScreenshotDetector";
+  }
+
+  @ReactMethod
+  public void enableScreenshots() {
+    getCurrentActivity().runOnUiThread(new Runnable() {
+      @Override
+      public void run() {
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
+      }
+    });
+  }
+
+  @ReactMethod
+  public void disableScreenshots() {
+    getCurrentActivity().runOnUiThread(new Runnable() {
+      @Override
+      public void run() {
+        getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
+      }
+    });
+  }
+
+  private Window getWindow() {
+    return getCurrentActivity().getWindow();
+  }
+}

--- a/android/src/main/java/com/reactlibrary/RNScreenshotDetectorPackage.java
+++ b/android/src/main/java/com/reactlibrary/RNScreenshotDetectorPackage.java
@@ -1,0 +1,28 @@
+
+package com.reactlibrary;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+import com.facebook.react.bridge.JavaScriptModule;
+public class RNScreenshotDetectorPackage implements ReactPackage {
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+      return Arrays.<NativeModule>asList(new RNScreenshotDetectorModule(reactContext));
+    }
+
+    // Deprecated from RN 0.47
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+      return Collections.emptyList();
+    }
+
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+      return Collections.emptyList();
+    }
+}

--- a/index.android.js
+++ b/index.android.js
@@ -1,0 +1,8 @@
+// TODO: check out https://github.com/abangfadli/shotwatch
+
+const unsubscribe = () => {}
+const subscribe = () => unsubscribe
+
+export default {
+  subscribe,
+}

--- a/index.android.js
+++ b/index.android.js
@@ -1,8 +1,13 @@
 // TODO: check out https://github.com/abangfadli/shotwatch
 
+import { NativeModules } from 'react-native'
+
 const unsubscribe = () => {}
 const subscribe = () => unsubscribe
 
-export default {
+const Detector = {
+  ...NativeModules.RNScreenshotDetector,
   subscribe,
 }
+
+export default Detector

--- a/index.android.js
+++ b/index.android.js
@@ -1,6 +1,9 @@
-// TODO: check out https://github.com/abangfadli/shotwatch
-
 import { NativeModules } from 'react-native'
+
+const LINKING_ERROR =
+  `@exodus/react-native-screenshot-detector: native module 'RNScreenshotDetector' is not linked. ` +
+  `Rebuild the Android app from source so the native module is bundled. ` +
+  `Refusing to no-op for security-critical screenshot protection.`
 
 const { RNScreenshotDetector } = NativeModules
 
@@ -8,15 +11,17 @@ const unsubscribe = () => {}
 const subscribe = () => unsubscribe
 
 const disableScreenshots = () => {
-  if (RNScreenshotDetector && RNScreenshotDetector.disableScreenshots) {
-    RNScreenshotDetector.disableScreenshots()
+  if (!RNScreenshotDetector || !RNScreenshotDetector.disableScreenshots) {
+    throw new Error(LINKING_ERROR)
   }
+  RNScreenshotDetector.disableScreenshots()
 }
 
 const enableScreenshots = () => {
-  if (RNScreenshotDetector && RNScreenshotDetector.enableScreenshots) {
-    RNScreenshotDetector.enableScreenshots()
+  if (!RNScreenshotDetector || !RNScreenshotDetector.enableScreenshots) {
+    throw new Error(LINKING_ERROR)
   }
+  RNScreenshotDetector.enableScreenshots()
 }
 
 const Detector = {

--- a/index.android.js
+++ b/index.android.js
@@ -2,12 +2,27 @@
 
 import { NativeModules } from 'react-native'
 
+const { RNScreenshotDetector } = NativeModules
+
 const unsubscribe = () => {}
 const subscribe = () => unsubscribe
 
+const disableScreenshots = () => {
+  if (RNScreenshotDetector && RNScreenshotDetector.disableScreenshots) {
+    RNScreenshotDetector.disableScreenshots()
+  }
+}
+
+const enableScreenshots = () => {
+  if (RNScreenshotDetector && RNScreenshotDetector.enableScreenshots) {
+    RNScreenshotDetector.enableScreenshots()
+  }
+}
+
 const Detector = {
-  ...NativeModules.RNScreenshotDetector,
   subscribe,
+  disableScreenshots,
+  enableScreenshots,
 }
 
 export default Detector

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,59 +1,88 @@
 import { NativeEventEmitter, NativeModules } from 'react-native'
 
 const { RNScreenshotDetector } = NativeModules
+
+console.log('[TEST] RNScreenshotDetector module loaded:', !!RNScreenshotDetector)
+console.log('[TEST] Available methods:', Object.keys(RNScreenshotDetector || {}))
+
 const eventEmitter = new NativeEventEmitter(RNScreenshotDetector)
 
 const SCREENSHOT_EVENT = 'ScreenshotTaken'
 const SCREEN_RECORDING_EVENT = 'ScreenRecordingChanged'
 
 const subscribe = (cb) => {
-  const sub = eventEmitter.addListener(SCREENSHOT_EVENT, (data) => {
-    cb(data)
-  })
-  return () => {
-    sub.remove()
-  }
-}
-
-const subscribeToScreenRecording = (cb) => {
-  if (RNScreenshotDetector.subscribeToScreenRecording) {
-    RNScreenshotDetector.subscribeToScreenRecording()
+  console.log('[TEST] subscribe called - using NEW explicit method!')
+  
+  // Use the more explicit method name internally
+  if (RNScreenshotDetector && RNScreenshotDetector.subscribeToScreenshotAndScreenRecording) {
+    console.log('[TEST] Calling subscribeToScreenshotAndScreenRecording')
+    RNScreenshotDetector.subscribeToScreenshotAndScreenRecording()
+    console.log('[TEST] SUCCESS: subscribeToScreenshotAndScreenRecording called')
+  } else {
+    console.log('[TEST] ERROR: subscribeToScreenshotAndScreenRecording not available!')
   }
   
-  const sub = eventEmitter.addListener(SCREEN_RECORDING_EVENT, (data) => {
+  const sub = eventEmitter.addListener(SCREENSHOT_EVENT, (data) => {
+    console.log('[TEST] ScreenshotTaken event received:', data)
     cb(data)
   })
   return () => {
+    console.log('[TEST] Unsubscribing from screenshot events')
     sub.remove()
-    if (RNScreenshotDetector.unsubscribeFromScreenRecording) {
-      RNScreenshotDetector.unsubscribeFromScreenRecording()
+    
+    // Use the more explicit method name internally
+    if (RNScreenshotDetector && RNScreenshotDetector.unsubscribeFromScreenshotAndScreenRecording) {
+      console.log('[TEST] Calling unsubscribeFromScreenshotAndScreenRecording')
+      RNScreenshotDetector.unsubscribeFromScreenshotAndScreenRecording()
+      console.log('[TEST] SUCCESS: unsubscribeFromScreenshotAndScreenRecording called')
+    } else {
+      console.log('[TEST] ERROR: unsubscribeFromScreenshotAndScreenRecording not available!')
     }
   }
 }
 
 const disableScreenshots = () => {
-  if (RNScreenshotDetector.disableScreenshots) {
+  console.log('[TEST] disableScreenshots called')
+  if (RNScreenshotDetector && RNScreenshotDetector.disableScreenshots) {
+    console.log('[TEST] Calling native disableScreenshots')
     RNScreenshotDetector.disableScreenshots()
+    console.log('[TEST] SUCCESS: disableScreenshots called')
+  } else {
+    console.log('[TEST] ERROR: disableScreenshots not available!')
   }
 }
 
 const enableScreenshots = () => {
-  if (RNScreenshotDetector.enableScreenshots) {
+  console.log('[TEST] enableScreenshots called')
+  if (RNScreenshotDetector && RNScreenshotDetector.enableScreenshots) {
+    console.log('[TEST] Calling native enableScreenshots')
     RNScreenshotDetector.enableScreenshots()
+    console.log('[TEST] SUCCESS: enableScreenshots called')
+  } else {
+    console.log('[TEST] ERROR: enableScreenshots not available!')
   }
 }
 
 const isScreenRecording = async () => {
-  if (RNScreenshotDetector.isScreenRecording) {
-    return RNScreenshotDetector.isScreenRecording()
+  console.log('[TEST] isScreenRecording called')
+  if (RNScreenshotDetector && RNScreenshotDetector.isScreenRecording) {
+    try {
+      const result = await RNScreenshotDetector.isScreenRecording()
+      console.log('[TEST] isScreenRecording result:', result)
+      return result
+    } catch (error) {
+      console.log('[TEST] ERROR in isScreenRecording:', error)
+      return false
+    }
   } else {
+    console.log('[TEST] ERROR: isScreenRecording not available!')
     return false
   }
 }
 
+// Main API - only expose what's actually used externally
 const ScreenshotDetector = {
   subscribe,
-  subscribeToScreenRecording,
   disableScreenshots,
   enableScreenshots,
   isScreenRecording,

--- a/index.ios.js
+++ b/index.ios.js
@@ -4,12 +4,59 @@ const { RNScreenshotDetector } = NativeModules
 const eventEmitter = new NativeEventEmitter(RNScreenshotDetector)
 
 const SCREENSHOT_EVENT = 'ScreenshotTaken'
+const SCREEN_RECORDING_EVENT = 'ScreenRecordingChanged'
 
 const subscribe = (cb) => {
-  const sub = eventEmitter.addListener(SCREENSHOT_EVENT, cb, {})
-  return () => sub.remove()
+  const sub = eventEmitter.addListener(SCREENSHOT_EVENT, (data) => {
+    cb(data)
+  })
+  return () => {
+    sub.remove()
+  }
 }
 
-export default {
-  subscribe,
+const subscribeToScreenRecording = (cb) => {
+  if (RNScreenshotDetector.subscribeToScreenRecording) {
+    RNScreenshotDetector.subscribeToScreenRecording()
+  }
+  
+  const sub = eventEmitter.addListener(SCREEN_RECORDING_EVENT, (data) => {
+    cb(data)
+  })
+  return () => {
+    sub.remove()
+    if (RNScreenshotDetector.unsubscribeFromScreenRecording) {
+      RNScreenshotDetector.unsubscribeFromScreenRecording()
+    }
+  }
 }
+
+const disableScreenshots = () => {
+  if (RNScreenshotDetector.disableScreenshots) {
+    RNScreenshotDetector.disableScreenshots()
+  }
+}
+
+const enableScreenshots = () => {
+  if (RNScreenshotDetector.enableScreenshots) {
+    RNScreenshotDetector.enableScreenshots()
+  }
+}
+
+const isScreenRecording = async () => {
+  if (RNScreenshotDetector.isScreenRecording) {
+    return RNScreenshotDetector.isScreenRecording()
+  } else {
+    return false
+  }
+}
+
+const ScreenshotDetector = {
+  subscribe,
+  subscribeToScreenRecording,
+  disableScreenshots,
+  enableScreenshots,
+  isScreenRecording,
+}
+
+export default ScreenshotDetector

--- a/index.ios.js
+++ b/index.ios.js
@@ -2,85 +2,53 @@ import { NativeEventEmitter, NativeModules } from 'react-native'
 
 const { RNScreenshotDetector } = NativeModules
 
-console.log('[TEST] RNScreenshotDetector module loaded:', !!RNScreenshotDetector)
-console.log('[TEST] Available methods:', Object.keys(RNScreenshotDetector || {}))
-
 const eventEmitter = new NativeEventEmitter(RNScreenshotDetector)
 
 const SCREENSHOT_EVENT = 'ScreenshotTaken'
 const SCREEN_RECORDING_EVENT = 'ScreenRecordingChanged'
 
 const subscribe = (cb) => {
-  console.log('[TEST] subscribe called - using NEW explicit method!')
-  
-  // Use the more explicit method name internally
   if (RNScreenshotDetector && RNScreenshotDetector.subscribeToScreenshotAndScreenRecording) {
-    console.log('[TEST] Calling subscribeToScreenshotAndScreenRecording')
     RNScreenshotDetector.subscribeToScreenshotAndScreenRecording()
-    console.log('[TEST] SUCCESS: subscribeToScreenshotAndScreenRecording called')
-  } else {
-    console.log('[TEST] ERROR: subscribeToScreenshotAndScreenRecording not available!')
   }
   
   const sub = eventEmitter.addListener(SCREENSHOT_EVENT, (data) => {
-    console.log('[TEST] ScreenshotTaken event received:', data)
     cb(data)
   })
   return () => {
-    console.log('[TEST] Unsubscribing from screenshot events')
     sub.remove()
     
-    // Use the more explicit method name internally
     if (RNScreenshotDetector && RNScreenshotDetector.unsubscribeFromScreenshotAndScreenRecording) {
-      console.log('[TEST] Calling unsubscribeFromScreenshotAndScreenRecording')
       RNScreenshotDetector.unsubscribeFromScreenshotAndScreenRecording()
-      console.log('[TEST] SUCCESS: unsubscribeFromScreenshotAndScreenRecording called')
-    } else {
-      console.log('[TEST] ERROR: unsubscribeFromScreenshotAndScreenRecording not available!')
     }
   }
 }
 
 const disableScreenshots = () => {
-  console.log('[TEST] disableScreenshots called')
   if (RNScreenshotDetector && RNScreenshotDetector.disableScreenshots) {
-    console.log('[TEST] Calling native disableScreenshots')
     RNScreenshotDetector.disableScreenshots()
-    console.log('[TEST] SUCCESS: disableScreenshots called')
-  } else {
-    console.log('[TEST] ERROR: disableScreenshots not available!')
   }
 }
 
 const enableScreenshots = () => {
-  console.log('[TEST] enableScreenshots called')
   if (RNScreenshotDetector && RNScreenshotDetector.enableScreenshots) {
-    console.log('[TEST] Calling native enableScreenshots')
     RNScreenshotDetector.enableScreenshots()
-    console.log('[TEST] SUCCESS: enableScreenshots called')
-  } else {
-    console.log('[TEST] ERROR: enableScreenshots not available!')
   }
 }
 
 const isScreenRecording = async () => {
-  console.log('[TEST] isScreenRecording called')
   if (RNScreenshotDetector && RNScreenshotDetector.isScreenRecording) {
     try {
       const result = await RNScreenshotDetector.isScreenRecording()
-      console.log('[TEST] isScreenRecording result:', result)
       return result
     } catch (error) {
-      console.log('[TEST] ERROR in isScreenRecording:', error)
       return false
     }
   } else {
-    console.log('[TEST] ERROR: isScreenRecording not available!')
     return false
   }
 }
 
-// Main API - only expose what's actually used externally
 const ScreenshotDetector = {
   subscribe,
   disableScreenshots,

--- a/index.ios.js
+++ b/index.ios.js
@@ -11,6 +11,5 @@ const subscribe = (cb) => {
 }
 
 export default {
-  SCREENSHOT_EVENT,
   subscribe,
 }

--- a/index.js
+++ b/index.js
@@ -1,15 +1,16 @@
+import { NativeEventEmitter, NativeModules } from 'react-native'
 
-import { NativeEventEmitter, NativeModules } from 'react-native';
-const { RNScreenshotDetector } = NativeModules;
+const { RNScreenshotDetector } = NativeModules
+const eventEmitter = new NativeEventEmitter(RNScreenshotDetector)
 
-export const SCREENSHOT_EVENT = 'ScreenshotTaken';
+const SCREENSHOT_EVENT = 'ScreenshotTaken'
 
-export function subscribe(cb) {
-  const eventEmitter = new NativeEventEmitter(RNScreenshotDetector);
-  eventEmitter.addListener(SCREENSHOT_EVENT, cb, {});
-  return eventEmitter;
+const subscribe = (cb) => {
+  const sub = eventEmitter.addListener(SCREENSHOT_EVENT, cb, {})
+  return () => sub.remove()
 }
 
-export function unsubscribe(eventEmitter) {
-  eventEmitter.removeAllListeners(SCREENSHOT_EVENT);
+export default {
+  SCREENSHOT_EVENT,
+  subscribe,
 }

--- a/ios/RNScreenshotDetector/RNScreenshotDetector.h
+++ b/ios/RNScreenshotDetector/RNScreenshotDetector.h
@@ -9,6 +9,9 @@
 
 @interface RNScreenshotDetector : RCTEventEmitter <RCTBridgeModule>
 
+@property (nonatomic, strong) UITextField *secureTextField;
+
 - (void)screenshotDetected:(NSNotification*)notification;
+- (void)screenRecordingChanged:(NSNotification*)notification;
 
 @end

--- a/ios/RNScreenshotDetector/RNScreenshotDetector.h
+++ b/ios/RNScreenshotDetector/RNScreenshotDetector.h
@@ -9,7 +9,6 @@
 
 @interface RNScreenshotDetector : RCTEventEmitter <RCTBridgeModule>
 
-- (void)setupAndListen:(RCTBridge*)bridge;
 - (void)screenshotDetected:(NSNotification*)notification;
 
 @end

--- a/ios/RNScreenshotDetector/RNScreenshotDetector.m
+++ b/ios/RNScreenshotDetector/RNScreenshotDetector.m
@@ -6,40 +6,161 @@
 
 #import "RNScreenshotDetector.h"
 #import <React/RCTBridge.h>
+#import <UIKit/UIKit.h>
 
 @implementation RNScreenshotDetector
 {
-    id observer;
+    id screenshotObserver;
+    id screenRecordingObserver;
+    UIView *securityOverlay;
+    BOOL isProtectionEnabled;
 }
 
 RCT_EXPORT_MODULE();
 
-
 - (NSArray<NSString *> *)supportedEvents {
-    return @[@"ScreenshotTaken"];
+    return @[@"ScreenshotTaken", @"ScreenRecordingChanged"];
 }
 
 - (void)startObserving {
-   // Now set up handler to detect if user takes a screenshot
     NSOperationQueue *mainQueue = [NSOperationQueue mainQueue];
-    observer = [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationUserDidTakeScreenshotNotification
-                                                      object:nil
-                                                       queue:mainQueue
-                                                  usingBlock:^(NSNotification *notification) {
-                                                      [self screenshotDetected:notification];
-                                                  }];
+    screenshotObserver = [[NSNotificationCenter defaultCenter] 
+        addObserverForName:UIApplicationUserDidTakeScreenshotNotification
+        object:nil
+        queue:mainQueue
+        usingBlock:^(NSNotification *notification) {
+            [self screenshotDetected:notification];
+        }];
+    
+    screenRecordingObserver = [[NSNotificationCenter defaultCenter]
+        addObserverForName:UIScreenCapturedDidChangeNotification
+        object:nil
+        queue:mainQueue
+        usingBlock:^(NSNotification *notification) {
+            [self screenRecordingChanged:notification];
+        }];
 }
 
 - (void)stopObserving {
-    if (observer != nil) {
-        [[NSNotificationCenter defaultCenter] removeObserver:observer];
+    if (screenshotObserver != nil) {
+        [[NSNotificationCenter defaultCenter] removeObserver:screenshotObserver];
+        screenshotObserver = nil;
+    }
+    
+    if (screenRecordingObserver != nil) {
+        [[NSNotificationCenter defaultCenter] removeObserver:screenRecordingObserver];
+        screenRecordingObserver = nil;
     }
 }
 
 - (void)screenshotDetected:(NSNotification *)notification {
-    if (observer != nil) {
+    if (screenshotObserver != nil) {
         [self sendEventWithName:@"ScreenshotTaken" body:@{}];
     }
 }
 
-@end
+- (void)screenRecordingChanged:(NSNotification *)notification {
+    if (screenRecordingObserver != nil) {
+        BOOL isRecording = [UIScreen mainScreen].isCaptured;
+        
+        [self sendEventWithName:@"ScreenRecordingChanged" body:@{@"isRecording": @(isRecording)}];
+    }
+}
+
+RCT_EXPORT_METHOD(disableScreenshots) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        isProtectionEnabled = YES;
+        [self enableTrueScreenshotPrevention];
+    });
+}
+
+RCT_EXPORT_METHOD(enableScreenshots) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        isProtectionEnabled = NO;
+        [self disableTrueScreenshotPrevention];
+    });
+}
+
+RCT_EXPORT_METHOD(isScreenRecording:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    BOOL isRecording = [UIScreen mainScreen].isCaptured;
+    resolve(@(isRecording));
+}
+
+RCT_EXPORT_METHOD(subscribeToScreenRecording) {
+    [self startObserving];
+}
+
+RCT_EXPORT_METHOD(unsubscribeFromScreenRecording) {
+    [self stopObserving];
+}
+
+// Screenshot Prevention using Secure Text Field
+- (void)enableTrueScreenshotPrevention {
+    if (self.secureTextField == nil) {
+        self.secureTextField = [[UITextField alloc] init];
+        self.secureTextField.userInteractionEnabled = NO;
+        self.secureTextField.secureTextEntry = YES;
+        
+        UIWindow *keyWindow = [self getKeyWindow];
+        if (keyWindow != nil) {
+            [keyWindow makeKeyAndVisible];
+            
+            // Make the app window a sublayer of the secure text field
+            [keyWindow.layer.superlayer addSublayer:self.secureTextField.layer];
+            
+            // Add the window layer as a sublayer of the secure text field's first sublayer
+            NSArray *sublayers = self.secureTextField.layer.sublayers;
+            if (sublayers.count > 0) {
+                [sublayers.firstObject addSublayer:keyWindow.layer];
+            }
+        }
+    } else {
+        self.secureTextField.secureTextEntry = YES;
+    }
+}
+
+- (void)disableTrueScreenshotPrevention {
+    if (self.secureTextField != nil) {
+        self.secureTextField.secureTextEntry = NO;
+    }
+}
+
+- (UIWindow *)getKeyWindow {
+    UIWindow *keyWindow = nil;
+    
+    NSSet<UIScene *> *connectedScenes = [UIApplication sharedApplication].connectedScenes;
+    for (UIScene *scene in connectedScenes) {
+        if ([scene isKindOfClass:[UIWindowScene class]]) {
+            UIWindowScene *windowScene = (UIWindowScene *)scene;
+            for (UIWindow *window in windowScene.windows) {
+                if (window.isKeyWindow) {
+                    keyWindow = window;
+                    break;
+                }
+            }
+            if (keyWindow) break;
+        }
+    }
+    
+    if (keyWindow == nil) {
+        keyWindow = [UIApplication sharedApplication].keyWindow;
+        if (keyWindow == nil) {
+            for (UIWindow *window in [UIApplication sharedApplication].windows) {
+                if (window.isKeyWindow) {
+                    keyWindow = window;
+                    break;
+                }
+            }
+        }
+    }
+    
+    return keyWindow;
+}
+
+- (void)dealloc {
+    [self stopObserving];
+    [self disableTrueScreenshotPrevention];
+}
+
+@end 

--- a/ios/RNScreenshotDetector/RNScreenshotDetector.m
+++ b/ios/RNScreenshotDetector/RNScreenshotDetector.m
@@ -12,98 +12,138 @@
 {
     id screenshotObserver;
     id screenRecordingObserver;
-    UIView *securityOverlay;
     BOOL isProtectionEnabled;
 }
 
 RCT_EXPORT_MODULE();
 
 - (NSArray<NSString *> *)supportedEvents {
+    NSLog(@"[TEST] supportedEvents called");
     return @[@"ScreenshotTaken", @"ScreenRecordingChanged"];
 }
 
 - (void)startObserving {
+    NSLog(@"[TEST] startObserving called");
     NSOperationQueue *mainQueue = [NSOperationQueue mainQueue];
-    screenshotObserver = [[NSNotificationCenter defaultCenter] 
-        addObserverForName:UIApplicationUserDidTakeScreenshotNotification
-        object:nil
-        queue:mainQueue
-        usingBlock:^(NSNotification *notification) {
-            [self screenshotDetected:notification];
-        }];
     
-    screenRecordingObserver = [[NSNotificationCenter defaultCenter]
-        addObserverForName:UIScreenCapturedDidChangeNotification
-        object:nil
-        queue:mainQueue
-        usingBlock:^(NSNotification *notification) {
-            [self screenRecordingChanged:notification];
-        }];
+    if (screenshotObserver == nil) {
+        screenshotObserver = [[NSNotificationCenter defaultCenter] 
+            addObserverForName:UIApplicationUserDidTakeScreenshotNotification
+            object:nil
+            queue:mainQueue
+            usingBlock:^(NSNotification *notification) {
+                [self screenshotDetected:notification];
+            }];
+        NSLog(@"[TEST] Screenshot observer registered successfully");
+    } else {
+        NSLog(@"[TEST] Screenshot observer already exists");
+    }
+    
+    if (screenRecordingObserver == nil) {
+        screenRecordingObserver = [[NSNotificationCenter defaultCenter]
+            addObserverForName:UIScreenCapturedDidChangeNotification
+            object:nil
+            queue:mainQueue
+            usingBlock:^(NSNotification *notification) {
+                [self screenRecordingChanged:notification];
+            }];
+        NSLog(@"[TEST] Screen recording observer registered successfully");
+    } else {
+        NSLog(@"[TEST] Screen recording observer already exists");
+    }
 }
 
 - (void)stopObserving {
+    NSLog(@"[TEST] stopObserving called");
     if (screenshotObserver != nil) {
         [[NSNotificationCenter defaultCenter] removeObserver:screenshotObserver];
         screenshotObserver = nil;
+        NSLog(@"[TEST] Screenshot observer removed successfully");
     }
     
     if (screenRecordingObserver != nil) {
         [[NSNotificationCenter defaultCenter] removeObserver:screenRecordingObserver];
         screenRecordingObserver = nil;
+        NSLog(@"[TEST] Screen recording observer removed successfully");
     }
 }
 
 - (void)screenshotDetected:(NSNotification *)notification {
+    NSLog(@"[TEST] 🚨 SCREENSHOT DETECTED! 🚨");
     if (screenshotObserver != nil) {
+        NSLog(@"[TEST] Sending ScreenshotTaken event to JavaScript");
         [self sendEventWithName:@"ScreenshotTaken" body:@{}];
+        NSLog(@"[TEST] ScreenshotTaken event sent successfully");
+    } else {
+        NSLog(@"[TEST] ERROR: Screenshot observer is nil, not sending event");
     }
 }
 
 - (void)screenRecordingChanged:(NSNotification *)notification {
+    BOOL isRecording = [UIScreen mainScreen].isCaptured;
+    NSLog(@"[TEST] Screen recording changed: %@", isRecording ? @"STARTED" : @"STOPPED");
+    
     if (screenRecordingObserver != nil) {
-        BOOL isRecording = [UIScreen mainScreen].isCaptured;
-        
+        NSLog(@"[TEST] Sending ScreenRecordingChanged event to JavaScript");
         [self sendEventWithName:@"ScreenRecordingChanged" body:@{@"isRecording": @(isRecording)}];
+        NSLog(@"[TEST] ScreenRecordingChanged event sent successfully");
+    } else {
+        NSLog(@"[TEST] ERROR: Screen recording observer is nil, not sending event");
     }
 }
 
 RCT_EXPORT_METHOD(disableScreenshots) {
+    NSLog(@"[TEST] disableScreenshots called");
     dispatch_async(dispatch_get_main_queue(), ^{
         isProtectionEnabled = YES;
+        NSLog(@"[TEST] Protection enabled, calling enableTrueScreenshotPrevention");
         [self enableTrueScreenshotPrevention];
+        NSLog(@"[TEST] disableScreenshots completed");
     });
 }
 
 RCT_EXPORT_METHOD(enableScreenshots) {
+    NSLog(@"[TEST] enableScreenshots called");
     dispatch_async(dispatch_get_main_queue(), ^{
         isProtectionEnabled = NO;
+        NSLog(@"[TEST] Protection disabled, calling disableTrueScreenshotPrevention");
         [self disableTrueScreenshotPrevention];
+        NSLog(@"[TEST] enableScreenshots completed");
     });
 }
 
 RCT_EXPORT_METHOD(isScreenRecording:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     BOOL isRecording = [UIScreen mainScreen].isCaptured;
+    NSLog(@"[TEST] isScreenRecording called, result: %@", isRecording ? @"YES" : @"NO");
     resolve(@(isRecording));
 }
 
-RCT_EXPORT_METHOD(subscribeToScreenRecording) {
+// Clear and explicit method names
+RCT_EXPORT_METHOD(subscribeToScreenshotAndScreenRecording) {
+    NSLog(@"[TEST] subscribeToScreenshotAndScreenRecording called - NEW EXPLICIT METHOD!");
     [self startObserving];
+    NSLog(@"[TEST] subscribeToScreenshotAndScreenRecording completed");
 }
 
-RCT_EXPORT_METHOD(unsubscribeFromScreenRecording) {
+RCT_EXPORT_METHOD(unsubscribeFromScreenshotAndScreenRecording) {
+    NSLog(@"[TEST] unsubscribeFromScreenshotAndScreenRecording called");
     [self stopObserving];
+    NSLog(@"[TEST] unsubscribeFromScreenshotAndScreenRecording completed");
 }
 
 // Screenshot Prevention using Secure Text Field
 - (void)enableTrueScreenshotPrevention {
+    NSLog(@"[TEST] enableTrueScreenshotPrevention called");
     if (self.secureTextField == nil) {
+        NSLog(@"[TEST] Creating new secureTextField");
         self.secureTextField = [[UITextField alloc] init];
         self.secureTextField.userInteractionEnabled = NO;
         self.secureTextField.secureTextEntry = YES;
         
         UIWindow *keyWindow = [self getKeyWindow];
         if (keyWindow != nil) {
+            NSLog(@"[TEST] Key window found, setting up secure text field");
             [keyWindow makeKeyAndVisible];
             
             // Make the app window a sublayer of the secure text field
@@ -113,29 +153,46 @@ RCT_EXPORT_METHOD(unsubscribeFromScreenRecording) {
             NSArray *sublayers = self.secureTextField.layer.sublayers;
             if (sublayers.count > 0) {
                 [sublayers.firstObject addSublayer:keyWindow.layer];
+                NSLog(@"[TEST] ✅ Secure text field configured successfully - Screenshot prevention ACTIVE!");
+            } else {
+                NSLog(@"[TEST] ❌ No sublayers found in secure text field");
             }
+        } else {
+            NSLog(@"[TEST] ❌ Key window not found!");
         }
     } else {
+        NSLog(@"[TEST] Secure text field already exists, enabling secureTextEntry");
         self.secureTextField.secureTextEntry = YES;
+        NSLog(@"[TEST] ✅ Secure text field re-enabled - Screenshot prevention ACTIVE!");
     }
 }
 
 - (void)disableTrueScreenshotPrevention {
+    NSLog(@"[TEST] disableTrueScreenshotPrevention called");
     if (self.secureTextField != nil) {
+        NSLog(@"[TEST] Disabling secureTextEntry");
         self.secureTextField.secureTextEntry = NO;
+        NSLog(@"[TEST] ✅ Screenshot prevention DISABLED");
+    } else {
+        NSLog(@"[TEST] Secure text field is nil");
     }
 }
 
 - (UIWindow *)getKeyWindow {
+    NSLog(@"[TEST] getKeyWindow called");
     UIWindow *keyWindow = nil;
     
     NSSet<UIScene *> *connectedScenes = [UIApplication sharedApplication].connectedScenes;
+    NSLog(@"[TEST] Connected scenes count: %lu", (unsigned long)connectedScenes.count);
+    
     for (UIScene *scene in connectedScenes) {
         if ([scene isKindOfClass:[UIWindowScene class]]) {
             UIWindowScene *windowScene = (UIWindowScene *)scene;
+            NSLog(@"[TEST] Found window scene with %lu windows", (unsigned long)windowScene.windows.count);
             for (UIWindow *window in windowScene.windows) {
                 if (window.isKeyWindow) {
                     keyWindow = window;
+                    NSLog(@"[TEST] ✅ Found key window using UIScene method");
                     break;
                 }
             }
@@ -144,21 +201,14 @@ RCT_EXPORT_METHOD(unsubscribeFromScreenRecording) {
     }
     
     if (keyWindow == nil) {
-        keyWindow = [UIApplication sharedApplication].keyWindow;
-        if (keyWindow == nil) {
-            for (UIWindow *window in [UIApplication sharedApplication].windows) {
-                if (window.isKeyWindow) {
-                    keyWindow = window;
-                    break;
-                }
-            }
-        }
+        NSLog(@"[TEST] ❌ Key window not found using UIScene method!");
     }
     
     return keyWindow;
 }
 
 - (void)dealloc {
+    NSLog(@"[TEST] dealloc called");
     [self stopObserving];
     [self disableTrueScreenshotPrevention];
 }

--- a/ios/RNScreenshotDetector/RNScreenshotDetector.m
+++ b/ios/RNScreenshotDetector/RNScreenshotDetector.m
@@ -18,12 +18,10 @@
 RCT_EXPORT_MODULE();
 
 - (NSArray<NSString *> *)supportedEvents {
-    NSLog(@"[TEST] supportedEvents called");
     return @[@"ScreenshotTaken", @"ScreenRecordingChanged"];
 }
 
 - (void)startObserving {
-    NSLog(@"[TEST] startObserving called");
     NSOperationQueue *mainQueue = [NSOperationQueue mainQueue];
     
     if (screenshotObserver == nil) {
@@ -34,9 +32,6 @@ RCT_EXPORT_MODULE();
             usingBlock:^(NSNotification *notification) {
                 [self screenshotDetected:notification];
             }];
-        NSLog(@"[TEST] Screenshot observer registered successfully");
-    } else {
-        NSLog(@"[TEST] Screenshot observer already exists");
     }
     
     if (screenRecordingObserver == nil) {
@@ -47,103 +42,73 @@ RCT_EXPORT_MODULE();
             usingBlock:^(NSNotification *notification) {
                 [self screenRecordingChanged:notification];
             }];
-        NSLog(@"[TEST] Screen recording observer registered successfully");
-    } else {
-        NSLog(@"[TEST] Screen recording observer already exists");
     }
 }
 
 - (void)stopObserving {
-    NSLog(@"[TEST] stopObserving called");
     if (screenshotObserver != nil) {
         [[NSNotificationCenter defaultCenter] removeObserver:screenshotObserver];
         screenshotObserver = nil;
-        NSLog(@"[TEST] Screenshot observer removed successfully");
     }
     
     if (screenRecordingObserver != nil) {
         [[NSNotificationCenter defaultCenter] removeObserver:screenRecordingObserver];
         screenRecordingObserver = nil;
-        NSLog(@"[TEST] Screen recording observer removed successfully");
     }
 }
 
 - (void)screenshotDetected:(NSNotification *)notification {
-    NSLog(@"[TEST] 🚨 SCREENSHOT DETECTED! 🚨");
     if (screenshotObserver != nil) {
-        NSLog(@"[TEST] Sending ScreenshotTaken event to JavaScript");
         [self sendEventWithName:@"ScreenshotTaken" body:@{}];
-        NSLog(@"[TEST] ScreenshotTaken event sent successfully");
-    } else {
-        NSLog(@"[TEST] ERROR: Screenshot observer is nil, not sending event");
     }
 }
 
 - (void)screenRecordingChanged:(NSNotification *)notification {
     BOOL isRecording = [UIScreen mainScreen].isCaptured;
-    NSLog(@"[TEST] Screen recording changed: %@", isRecording ? @"STARTED" : @"STOPPED");
     
     if (screenRecordingObserver != nil) {
-        NSLog(@"[TEST] Sending ScreenRecordingChanged event to JavaScript");
         [self sendEventWithName:@"ScreenRecordingChanged" body:@{@"isRecording": @(isRecording)}];
-        NSLog(@"[TEST] ScreenRecordingChanged event sent successfully");
-    } else {
-        NSLog(@"[TEST] ERROR: Screen recording observer is nil, not sending event");
     }
 }
 
 RCT_EXPORT_METHOD(disableScreenshots) {
-    NSLog(@"[TEST] disableScreenshots called");
     dispatch_async(dispatch_get_main_queue(), ^{
         isProtectionEnabled = YES;
-        NSLog(@"[TEST] Protection enabled, calling enableTrueScreenshotPrevention");
         [self enableTrueScreenshotPrevention];
-        NSLog(@"[TEST] disableScreenshots completed");
     });
 }
 
 RCT_EXPORT_METHOD(enableScreenshots) {
-    NSLog(@"[TEST] enableScreenshots called");
     dispatch_async(dispatch_get_main_queue(), ^{
         isProtectionEnabled = NO;
-        NSLog(@"[TEST] Protection disabled, calling disableTrueScreenshotPrevention");
         [self disableTrueScreenshotPrevention];
-        NSLog(@"[TEST] enableScreenshots completed");
     });
 }
 
 RCT_EXPORT_METHOD(isScreenRecording:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     BOOL isRecording = [UIScreen mainScreen].isCaptured;
-    NSLog(@"[TEST] isScreenRecording called, result: %@", isRecording ? @"YES" : @"NO");
     resolve(@(isRecording));
 }
 
 // Clear and explicit method names
 RCT_EXPORT_METHOD(subscribeToScreenshotAndScreenRecording) {
-    NSLog(@"[TEST] subscribeToScreenshotAndScreenRecording called - NEW EXPLICIT METHOD!");
     [self startObserving];
-    NSLog(@"[TEST] subscribeToScreenshotAndScreenRecording completed");
 }
 
 RCT_EXPORT_METHOD(unsubscribeFromScreenshotAndScreenRecording) {
-    NSLog(@"[TEST] unsubscribeFromScreenshotAndScreenRecording called");
     [self stopObserving];
-    NSLog(@"[TEST] unsubscribeFromScreenshotAndScreenRecording completed");
 }
 
 // Screenshot Prevention using Secure Text Field
 - (void)enableTrueScreenshotPrevention {
-    NSLog(@"[TEST] enableTrueScreenshotPrevention called");
     if (self.secureTextField == nil) {
-        NSLog(@"[TEST] Creating new secureTextField");
         self.secureTextField = [[UITextField alloc] init];
         self.secureTextField.userInteractionEnabled = NO;
         self.secureTextField.secureTextEntry = YES;
         
         UIWindow *keyWindow = [self getKeyWindow];
         if (keyWindow != nil) {
-            NSLog(@"[TEST] Key window found, setting up secure text field");
             [keyWindow makeKeyAndVisible];
             
             // Make the app window a sublayer of the secure text field
@@ -153,46 +118,30 @@ RCT_EXPORT_METHOD(unsubscribeFromScreenshotAndScreenRecording) {
             NSArray *sublayers = self.secureTextField.layer.sublayers;
             if (sublayers.count > 0) {
                 [sublayers.firstObject addSublayer:keyWindow.layer];
-                NSLog(@"[TEST] ✅ Secure text field configured successfully - Screenshot prevention ACTIVE!");
-            } else {
-                NSLog(@"[TEST] ❌ No sublayers found in secure text field");
             }
-        } else {
-            NSLog(@"[TEST] ❌ Key window not found!");
         }
     } else {
-        NSLog(@"[TEST] Secure text field already exists, enabling secureTextEntry");
         self.secureTextField.secureTextEntry = YES;
-        NSLog(@"[TEST] ✅ Secure text field re-enabled - Screenshot prevention ACTIVE!");
     }
 }
 
 - (void)disableTrueScreenshotPrevention {
-    NSLog(@"[TEST] disableTrueScreenshotPrevention called");
     if (self.secureTextField != nil) {
-        NSLog(@"[TEST] Disabling secureTextEntry");
         self.secureTextField.secureTextEntry = NO;
-        NSLog(@"[TEST] ✅ Screenshot prevention DISABLED");
-    } else {
-        NSLog(@"[TEST] Secure text field is nil");
     }
 }
 
 - (UIWindow *)getKeyWindow {
-    NSLog(@"[TEST] getKeyWindow called");
     UIWindow *keyWindow = nil;
     
     NSSet<UIScene *> *connectedScenes = [UIApplication sharedApplication].connectedScenes;
-    NSLog(@"[TEST] Connected scenes count: %lu", (unsigned long)connectedScenes.count);
     
     for (UIScene *scene in connectedScenes) {
         if ([scene isKindOfClass:[UIWindowScene class]]) {
             UIWindowScene *windowScene = (UIWindowScene *)scene;
-            NSLog(@"[TEST] Found window scene with %lu windows", (unsigned long)windowScene.windows.count);
             for (UIWindow *window in windowScene.windows) {
                 if (window.isKeyWindow) {
                     keyWindow = window;
-                    NSLog(@"[TEST] ✅ Found key window using UIScene method");
                     break;
                 }
             }
@@ -200,15 +149,10 @@ RCT_EXPORT_METHOD(unsubscribeFromScreenshotAndScreenRecording) {
         }
     }
     
-    if (keyWindow == nil) {
-        NSLog(@"[TEST] ❌ Key window not found using UIScene method!");
-    }
-    
     return keyWindow;
 }
 
 - (void)dealloc {
-    NSLog(@"[TEST] dealloc called");
     [self stopObserving];
     [self disableTrueScreenshotPrevention];
 }

--- a/ios/RNScreenshotDetector/RNScreenshotDetector.m
+++ b/ios/RNScreenshotDetector/RNScreenshotDetector.m
@@ -13,6 +13,8 @@
     id screenshotObserver;
     id screenRecordingObserver;
     BOOL isProtectionEnabled;
+    UIWindow *originalKeyWindow;      
+    CALayer *originalSuperlayer;      
 }
 
 RCT_EXPORT_MODULE();
@@ -91,7 +93,6 @@ RCT_EXPORT_METHOD(isScreenRecording:(RCTPromiseResolveBlock)resolve
     resolve(@(isRecording));
 }
 
-// Clear and explicit method names
 RCT_EXPORT_METHOD(subscribeToScreenshotAndScreenRecording) {
     [self startObserving];
 }
@@ -102,32 +103,58 @@ RCT_EXPORT_METHOD(unsubscribeFromScreenshotAndScreenRecording) {
 
 // Screenshot Prevention using Secure Text Field
 - (void)enableTrueScreenshotPrevention {
-    if (self.secureTextField == nil) {
-        self.secureTextField = [[UITextField alloc] init];
-        self.secureTextField.userInteractionEnabled = NO;
-        self.secureTextField.secureTextEntry = YES;
+    @try {
+        if (self.secureTextField == nil) {
+            self.secureTextField = [[UITextField alloc] init];
+            self.secureTextField.userInteractionEnabled = NO;
+            self.secureTextField.secureTextEntry = YES;
+        }
         
         UIWindow *keyWindow = [self getKeyWindow];
         if (keyWindow != nil) {
+            originalKeyWindow = keyWindow;
+            originalSuperlayer = keyWindow.layer.superlayer;
+            
             [keyWindow makeKeyAndVisible];
             
-            // Make the app window a sublayer of the secure text field
-            [keyWindow.layer.superlayer addSublayer:self.secureTextField.layer];
-            
-            // Add the window layer as a sublayer of the secure text field's first sublayer
-            NSArray *sublayers = self.secureTextField.layer.sublayers;
-            if (sublayers.count > 0) {
-                [sublayers.firstObject addSublayer:keyWindow.layer];
-            }
-        }
-    } else {
-        self.secureTextField.secureTextEntry = YES;
+            if (originalSuperlayer != nil) {
+                [originalSuperlayer addSublayer:self.secureTextField.layer];
+                
+                [keyWindow.layer removeFromSuperlayer];
+                
+                NSArray *sublayers = self.secureTextField.layer.sublayers;
+                if (sublayers.count > 0) {
+                    [sublayers.firstObject addSublayer:keyWindow.layer];
+                } else {
+                    [self.secureTextField.layer addSublayer:keyWindow.layer];
+                }
+            }   
+        } 
+    } @catch (NSException *exception) {
+        NSLog(@"[RNScreenshotDetector] Error in enableTrueScreenshotPrevention: %@", exception);
     }
 }
 
 - (void)disableTrueScreenshotPrevention {
-    if (self.secureTextField != nil) {
-        self.secureTextField.secureTextEntry = NO;
+    @try {
+        if (self.secureTextField != nil) {
+            self.secureTextField.secureTextEntry = NO;
+            
+            if (originalKeyWindow != nil && originalSuperlayer != nil) {
+                [originalKeyWindow.layer removeFromSuperlayer];
+                [originalSuperlayer addSublayer:originalKeyWindow.layer];
+                
+                [self.secureTextField.layer removeFromSuperlayer];
+            }
+            
+            originalKeyWindow = nil;
+            originalSuperlayer = nil;
+            
+            [self.secureTextField removeFromSuperview];
+            self.secureTextField = nil;
+        }
+    } @catch (NSException *exception) {
+        NSLog(@"[RNScreenshotDetector] Error in disableTrueScreenshotPrevention: %@", exception);
     }
 }
 

--- a/ios/RNScreenshotDetector/RNScreenshotDetector.m
+++ b/ios/RNScreenshotDetector/RNScreenshotDetector.m
@@ -6,22 +6,23 @@
 
 #import "RNScreenshotDetector.h"
 #import <React/RCTBridge.h>
-#import <React/RCTEventDispatcher.h>
 
 @implementation RNScreenshotDetector
+{
+    id observer;
+}
 
 RCT_EXPORT_MODULE();
+
 
 - (NSArray<NSString *> *)supportedEvents {
     return @[@"ScreenshotTaken"];
 }
 
-- (void)setupAndListen:(RCTBridge*)bridge {
-    // First set up native bridge
-    [self setBridge:bridge];
-    // Now set up handler to detect if user takes a screenshot
+- (void)startObserving {
+   // Now set up handler to detect if user takes a screenshot
     NSOperationQueue *mainQueue = [NSOperationQueue mainQueue];
-    [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationUserDidTakeScreenshotNotification
+    observer = [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationUserDidTakeScreenshotNotification
                                                       object:nil
                                                        queue:mainQueue
                                                   usingBlock:^(NSNotification *notification) {
@@ -29,8 +30,16 @@ RCT_EXPORT_MODULE();
                                                   }];
 }
 
+- (void)stopObserving {
+    if (observer != nil) {
+        [[NSNotificationCenter defaultCenter] removeObserver:observer];
+    }
+}
+
 - (void)screenshotDetected:(NSNotification *)notification {
-    [self.bridge.eventDispatcher sendAppEventWithName:@"ScreenshotTaken" body:nil];
+    if (observer != nil) {
+        [self sendEventWithName:@"ScreenshotTaken" body:@{}];
+    }
 }
 
 @end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/react-native-screenshot-detector",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "detect when the user takes a screenshot",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/react-native-screenshot-detector",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "detect when the user takes a screenshot",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/react-native-screenshot-detector",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "detect when the user takes a screenshot",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/react-native-screenshot-detector",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "detect when the user takes a screenshot",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/react-native-screenshot-detector",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "detect when the user takes a screenshot",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/react-native-screenshot-detector",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "detect when the user takes a screenshot",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/react-native-screenshot-detector",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "detect when the user takes a screenshot",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/react-native-screenshot-detector",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "detect when the user takes a screenshot",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/react-native-screenshot-detector",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "detect when the user takes a screenshot",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
 {
   "name": "react-native-screenshot-detector",
   "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
+  "description": "detect when the user takes a screenshot",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
-
 {
-  "name": "react-native-screenshot-detector",
+  "name": "@exodus/react-native-screenshot-detector",
   "version": "1.0.0",
   "description": "detect when the user takes a screenshot",
   "scripts": {
@@ -12,7 +11,7 @@
   "author": "gcarling",
   "repository": {
     "type": "git",
-    "url": "https://github.com/blendlabs/react-native-screenshot-detector"
+    "url": "https://github.com/ExodusMovement/react-native-screenshot-detector"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/react-native-screenshot-detector",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "detect when the user takes a screenshot",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/react-native-screenshot-detector",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "detect when the user takes a screenshot",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/react-native-screenshot-detector",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "detect when the user takes a screenshot",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Replace silent no-op in disableScreenshots/enableScreenshots with an explicit throw when NativeModules.RNScreenshotDetector or its method is absent. Silent no-op leaves FLAG_SECURE un-set, exposing seed-phrase / private-key screens to screen capture without any signal to the caller.

Bumps version to 1.2.7.

Refs: ExodusMovement/exodus-mobile#38080, https://github.com/ExodusMovement/exodus-mobile/pull/38081